### PR TITLE
Updated PKGBUILD to build python2 package correctly in Arch Linux.

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,31 +1,20 @@
-# $Id$
 # Maintainer: Mark Lamourine <markllama@gmail.com>
 
-pkgname('python-powerusb', 'python2-powerusb')
+pkgname=python2-powerusb
 pkgver=1.4
 pkgrel=1
 pkgdesc="Library and CLI tools to Control PowerUSB power strips."
 url="http://pwrusb.com"
-arch="any"
-license="Apache"
-makedepends=("python", "python2")
-source=(http://github.com/markllama/powerusb)
+arch=('any')
+license=('Apache')
+makedepends=('git' 'python2' 'python2-distribute')
+depends=('python2' 'python2-lxml' 'python2-pyusb')
+source=(git://github.com/markllama/powerusb.git)
+sha256sums=('SKIP')
 
-package_python-powerusb() {
-  depends=('python')
-
-  cd "$srcdir/powerusb-$pkgver"
-  python setup.py build
-  python setup.py install --prefix=/usr --root="$pkgdir"
-
-}
-
-package_python2-powerusb() {
+package() {
   depends=('python2')
-
-
-  cd "$srcdir/powerusb-$pkgver"
+  cd "$srcdir/powerusb"
   python2 setup.py build
   python2 setup.py install --prefix=/usr --root="$pkgdir"
-
 }


### PR DESCRIPTION
I've updated the PKGBUILD to the AUR; it can be found here:

https://aur.archlinux.org/packages/python2-powerusb/

This gets the package to compile correctly in Arch, including having all the
necessary python2 dependencies listed.

Hopefully this is helpful  :)
